### PR TITLE
Update package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "babel-cli": "latest",
     "babel-core": "latest",
     "babel-eslint": "latest",
-    "babel-loader": "latest",
+    "babel-loader": "7.1.1",
     "babel-plugin-transform-runtime": "latest",
     "babel-preset-es2015": "latest",
     "babel-preset-stage-0": "latest",
@@ -22,7 +22,7 @@
     "eslint-plugin-import": "latest",
     "eslint-plugin-jasmine": "latest",
     "jasmine": "latest",
-    "serverless-webpack": "latest",
+    "serverless-webpack": "1.0.0-rc.4",
     "webpack": "latest"
   },
   "dependencies": {


### PR DESCRIPTION
Dependency issues were causing the boilerplate to error our when attempting to run the test handler function.  This PR sets serverless-webpack to a version that was working on previous lambdas.  IT also downgrades babel-loader from 7.1.2 to 7.1.1.