### PR TITLE
Convert boilerplate handler functions to ES6

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -1,8 +1,8 @@
-function entry(event, context, callback) {
+const entry = (event, context, callback) => {
   //Method to run production code
 }
 
-function test() {
+const test = e => {
   //Method to run test code
   console.log("This is a test")
 }


### PR DESCRIPTION
The lambda boilerplate comes ES6 ready, but we havent been using the syntax in our handler file.  John and Ed had issues when trying to convert in the past while working on a different lambda function, so we left it in ES5 syntax.  I was able to successfully convert and get the functions to work with ES6 for the vimeo uploader lambda, so I think we are all good.  This PR updates the handler functions syntax.

Resolves: #533949236