### PR TITLE
Update Node Version 

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs8.10
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
https://execonline.leankit.com/card/684131049

If merged, this commit will change the node version because aws is dopping support for node 4.3. I update it to version 8.10

Resolves: 684131049